### PR TITLE
add multi-signing example to the sign() method

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5434,6 +5434,10 @@ return api.sign(txJSON, secret); // or: api.sign(txJSON, keypair);
 
 ```javascript
 const RippleAPI = require('ripple-lib').RippleAPI;
+const api = new RippleAPI({
+  server: 'wss://s.altnet.rippletest.net:51233' 
+
+});
 
 // jon's address has a multi-signing setup with a qourum of 2
 const jon = {
@@ -5477,6 +5481,9 @@ api.connect().then(() => {
     console.log(response);
   }).catch(console.error);
 }).catch(console.error)
+.then(() => {
+  return api.disconnect();
+}).catch(console.error);
 ```
 
 Assuming the multisigning account was setup properly, the above example will respond with `resultCode: 'tesSUCCESS'`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5402,6 +5402,8 @@ options | object | *Optional* Options that control the type of signature that wi
 *options.* signAs | [address](#address) | *Optional* The account that the signature should count for in multisigning.
 secret | secret string | *Optional* The secret of the account that is initiating the transaction. (This field is exclusive with keypair).
 
+Please note that when this method is used for multisigning, the `options` parameter is not *Optional* anymore. It will be compulsary. See the multisigning example in this section for more details. 
+
 ### Return Value
 
 This method returns an object with the following structure:
@@ -5428,6 +5430,60 @@ return api.sign(txJSON, secret); // or: api.sign(txJSON, keypair);
 }
 ```
 
+### Example (multisigning)
+
+```javascript
+const RippleAPI = require('ripple-lib').RippleAPI;
+
+// jon's address has a multi-signing setup with a qourum of 2
+const jon = {
+  account: 'ranYTqDRUKKAqnXAAVDwWBUvvc5op4pXoP',
+  secret: 'shfC5QySdfhCUaEfEF9gxPhAhy58u'
+};
+
+const aya = {
+  account: 'rnrPdBjs98fFFfmRpL6hM7exT788SWQPFN',
+  secret: 'snaMuMrXeVc2Vd4NYvHofeGNjgYoe'
+};
+
+const bran = {
+  account: 'rJ93RLnT1t5A8fCr7HTScw7WtfKJMRXodH',
+  secret: 'shQtQ8Um5MS218yvEU3Ehy1eZQKqH'
+};
+
+// a transaction which requires multi signing
+const multiSignPaymentTransaction = {
+    TransactionType: 'Payment',
+    Account: 'ranYTqDRUKKAqnXAAVDwWBUvvc5op4pXoP',
+    Sequence: 4,
+    Destination: 'rJ93RLnT1t5A8fCr7HTScw7WtfKJMRXodH',
+    Fee: '120',
+    Amount: '1888000000'
+};
+
+api.connect().then(() => {
+  let tx = JSON.stringify(multiSignPaymentTransaction, null, '\t');
+  
+  // Jon signs the original payment transaction
+  let jonSign = api.sign(tx, jon.secret).signedTransaction;
+  
+  // Aya and Bran sign it too but with 'signAs' set to their own account
+  let ayaSign = api.sign(tx, aya.secret, {'signAs': aya.account}).signedTransaction;
+  let branSign = api.sign(tx, bran.secret, {'signAs': bran.account})).signedTransaction;
+  
+  // signatures are combined and submitted
+  let combinedTx = api.combine([ayaSign, branSign]);
+  api.submit(combinedTx.signedTransaction).then ( (response) => {
+    console.log(response);
+  }).catch(console.error);
+}).catch(console.error)
+```
+
+Assuming the multisigning account was setup properly, the above example will respond with `resultCode: 'tesSUCCESS'`.
+If any of `{signAs: some_address}` options were missing the code will return a validation error as follow:
+```
+[ValidationError(txJSON is not the same for all signedTransactions)]
+```
 
 ## combine
 


### PR DESCRIPTION
Some description and an example added to explain why `signAs` option is compulsory for multi-signing scenarios.